### PR TITLE
Docs: Update README to brand as PoodlePilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# openpilot
+# PoodlePilot
 
 [![openpilot tests](https://github.com/commaai/openpilot/actions/workflows/selfdrive_tests.yaml/badge.svg)](https://github.com/commaai/openpilot/actions/workflows/selfdrive_tests.yaml)
 [![codecov](https://codecov.io/gh/commaai/openpilot/branch/master/graph/badge.svg)](https://codecov.io/gh/commaai/openpilot)
@@ -7,10 +7,11 @@
 [![Discord](https://img.shields.io/discord/469524606043160576)](https://discord.comma.ai)
 [![Version](https://img.shields.io/github/v/release/commaai/openpilot)](https://github.com/commaai/openpilot/releases/latest)
 <!-- Add other relevant badges here if available, e.g., for specific sub-components or documentation status -->
+<!-- Note: Badges for tests, codecov, and version currently point to the original openpilot repository. These should be updated if PoodlePilot establishes its own CI and release cycle. -->
 
-**openpilot is an open source driver assistance system.** It enhances compatible vehicles with features like Automated Lane Centering (ALC) and Adaptive Cruise Control (ACC). Developed by [comma.ai](https://comma.ai/) and the community, openpilot aims to provide a safe and reliable driving experience.
+**PoodlePilot is an open source driver assistance system, forked from [comma.ai's openpilot](https://github.com/commaai/openpilot).** PoodlePilot enhances compatible vehicles with features like Automated Lane Centering (ALC) and Adaptive Cruise Control (ACC). Originally developed by [comma.ai](https://comma.ai/) and the community, PoodlePilot aims to provide a safe and reliable driving experience.
 
-This document provides information for developers and contributors looking to understand, build, and extend openpilot. For user-facing documentation, please visit [docs.comma.ai](https://docs.comma.ai).
+This document provides information for developers and contributors looking to understand, build, and extend PoodlePilot. For user-facing documentation, please visit [docs.comma.ai](https://docs.comma.ai) (official OpenPilot documentation).
 
 ## Table of Contents
 
@@ -22,7 +23,7 @@ This document provides information for developers and contributors looking to un
   - [On a comma device](#on-a-comma-device)
   - [In Simulation](#in-simulation)
 - [Running Tests](#running-tests)
-- [Building openpilot](#building-openpilot)
+- [Building PoodlePilot](#building-poodlepilot)
 - [Deployment](#deployment)
 - [High-Level Architecture](#high-level-architecture)
 - [Contributing](#contributing)
@@ -30,7 +31,7 @@ This document provides information for developers and contributors looking to un
 
 ## Getting Started
 
-This section guides you through setting up your development environment for openpilot.
+This section guides you through setting up your development environment for PoodlePilot.
 
 ### Prerequisites
 
@@ -53,9 +54,10 @@ Before you begin, ensure you have the following:
     git clone https://github.com/commaai/openpilot.git
     cd openpilot
     ```
+    <!-- TODO: Update this URL if/when PoodlePilot has its own repository -->
 
 2.  **Initialize Submodules & LFS:**
-    openpilot uses Git submodules and LFS.
+    PoodlePilot uses Git submodules and LFS.
     ```bash
     git submodule update --init --recursive
     git lfs pull
@@ -96,16 +98,16 @@ Before you begin, ensure you have the following:
 
 ### On a comma device
 
-For running openpilot on a comma 3/3X:
-1.  Follow the [official installation instructions from comma.ai](https://comma.ai/setup).
-2.  To use a custom build (e.g., from your development branch), you typically need to build and transfer it to the device. The `release/` directory scripts, particularly `release/build_release.sh` (which calls `release/pack.py`), are used for creating deployable builds.
+For running PoodlePilot on a comma 3/3X:
+1.  Follow the [official OpenPilot installation instructions from comma.ai](https://comma.ai/setup).
+2.  To use a custom PoodlePilot build (e.g., from your development branch), you typically need to build and transfer it to the device. The `release/` directory scripts, particularly `release/build_release.sh` (which calls `release/pack.py`), are used for creating deployable builds.
     *Further details on deploying custom builds to devices will be added here or in specific Wiki sections once the process is fully documented.*
 
 ### In Simulation
 
-openpilot can be run in a simulator, which is highly beneficial for development and testing without needing a car or comma hardware.
+PoodlePilot can be run in a simulator, which is highly beneficial for development and testing without needing a car or comma hardware.
 *   **Setup and Run Simulation:**
-    The `tools/sim/launch_openpilot.sh` script configures and starts openpilot in simulation mode.
+    The `tools/sim/launch_openpilot.sh` script configures and starts PoodlePilot in simulation mode.
     Make sure your virtual environment is active (`source .venv/bin/activate`).
     ```bash
     # From the root of the openpilot directory
@@ -116,7 +118,7 @@ openpilot can be run in a simulator, which is highly beneficial for development 
 
 ## Running Tests
 
-openpilot has an extensive suite of tests, combining Python and C++ tests, primarily run using `pytest`.
+PoodlePilot has an extensive suite of tests, combining Python and C++ tests, primarily run using `pytest`.
 Ensure your Python virtual environment is active (`source .venv/bin/activate`).
 
 *   **General Testing:**
@@ -146,9 +148,9 @@ Ensure your Python virtual environment is active (`source .venv/bin/activate`).
     # View HTML report: coverage html
     ```
 
-## Building openpilot
+## Building PoodlePilot
 
-openpilot is primarily built using SCons. Ensure your Python virtual environment is active (`source .venv/bin/activate`).
+PoodlePilot is primarily built using SCons. Ensure your Python virtual environment is active (`source .venv/bin/activate`).
 
 1.  **Standard Development Build:**
     To build all targets. SCons will typically use about half your CPU cores by default.
@@ -182,19 +184,19 @@ openpilot is primarily built using SCons. Ensure your Python virtual environment
 
 ## Deployment
 
-Deployment typically refers to installing openpilot on a comma device.
-*   **Official Releases:** Users install official releases via URLs like `openpilot.comma.ai` during the device setup.
+Deployment typically refers to installing PoodlePilot on a comma device.
+*   **Official Releases:** Users install official OpenPilot releases via URLs like `openpilot.comma.ai` during the device setup. For PoodlePilot, release mechanisms will be defined by its maintainers.
 *   **Custom Builds / Development Builds:**
-    1.  Build openpilot using the appropriate release scripts (e.g., `./release/build_devel.sh`). This usually creates an update package.
-    2.  Transfer the package to the comma device. This might involve SSH, USB, or a custom update mechanism. Consult the openpilot documentation and community discussions for methods.
+    1.  Build PoodlePilot using the appropriate release scripts (e.g., `./release/build_devel.sh`). This usually creates an update package.
+    2.  Transfer the package to the comma device. This might involve SSH, USB, or a custom update mechanism. Consult the OpenPilot documentation and community discussions for methods, adapting as necessary for PoodlePilot.
     3.  Install the update on the device.
     *This section will be significantly expanded in the Wiki documentation with detailed procedures.*
 
 ## High-Level Architecture
 
-openpilot's architecture is modular, consisting of several key systems and processes that communicate with each other, primarily using the `cereal` messaging library.
+PoodlePilot's architecture (derived from OpenPilot) is modular, consisting of several key systems and processes that communicate with each other, primarily using the `cereal` messaging library.
 
-*   **Core Components:**
+*   **Core Components (inherited from OpenPilot):**
     *   **`selfdrive`**: The primary software for autonomous driving capabilities.
         *   **`controls`**: Manages vehicle control (steering, acceleration, braking) through `controlsd`, `plannerd`, and `radard`.
         *   **`modeld`**: Runs machine learning models for perception (e.g., path planning, object detection).
@@ -221,14 +223,16 @@ openpilot's architecture is modular, consisting of several key systems and proce
 
 ## Contributing
 
-We welcome contributions to openpilot! Please see our detailed [Contribution Guidelines](docs/CONTRIBUTING.md) and the project's Code of Conduct (link to be added or file created).
+We welcome contributions to PoodlePilot! Please see our detailed [Contribution Guidelines](docs/CONTRIBUTING.md) (Note: this currently points to the original OpenPilot guidelines and may need to be adapted for PoodlePilot) and the project's Code of Conduct (link to be added or file created).
 
 Key points:
 *   Priorities: Safety, stability, quality, features (in that order).
-*   Check existing issues and discussions before starting work.
-*   Follow coding style and submit well-tested pull requests.
-*   Join the [openpilot community Discord](https://discord.comma.ai) for discussions with other developers and users.
+*   Check existing issues and discussions before starting work (refer to PoodlePilot's issue tracker if separate from OpenPilot's).
+*   Follow coding style and submit well-tested pull requests to the PoodlePilot repository.
+*   Join the [OpenPilot community Discord](https://discord.comma.ai) for discussions with other developers and users. (PoodlePilot specific channels may be established here or elsewhere in the future).
 
 ## License
 
-openpilot is released under the MIT License. See the [LICENSE](LICENSE) file for more details. Some components may be under different licenses as specified within their respective directories.
+PoodlePilot is a fork of OpenPilot and is also released under the MIT License. See the [LICENSE](LICENSE) file for more details.
+The original OpenPilot software is copyrighted by comma.ai and its contributors.
+Some components inherited from OpenPilot may be under different licenses as specified within their respective directories.


### PR DESCRIPTION
This commit updates the main README.md file to reflect the PoodlePilot branding.

Key changes include:
- Renaming the project to PoodlePilot in the title and throughout the document.
- Clarifying that PoodlePilot is a fork of comma.ai's OpenPilot.
- Preserving links to original OpenPilot documentation and resources where relevant.
- Adding notes for future updates (e.g., CI badges, repository URLs).
- Ensuring the license information reflects the fork status and acknowledges the original OpenPilot copyright.

<!-- Please copy and paste the relevant template -->

<!--- ***** Template: Fingerprint *****

**Car**
Which car (make, model, year) this fingerprint is for

**Route**
A route with the fingerprint

-->

<!--- ***** Template: Car Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 

**Route**

Route: [a route with the bug fix]


-->

<!--- ***** Template: Bugfix *****

**Description**

A description of the bug and the fix. Also link the issue if it exists. 

**Verification**

Explain how you tested this bug fix. 


-->

<!--- ***** Template: Car Port *****

**Checklist**

- [ ] added entry to CAR in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system:
- [ ] car harness used (if comma doesn't sell it, put N/A):


-->

<!--- ***** Template: Refactor *****

**Description**

A description of the refactor, including the goals it accomplishes. 

**Verification**

Explain how you tested the refactor for regressions. 


-->

